### PR TITLE
Identity-first homepage redesign with Substack feed

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -4,9 +4,13 @@ const year = new Date().getFullYear();
 ---
 
 <footer class="site-footer">
-  <p class="site-footer-sign">GM from Tel Aviv. <em>GN from Miami.</em></p>
+  <div>
+    <p class="site-footer-sign">GM from Tel Aviv. <em>GN from Miami.</em></p>
+    <p class="site-footer-quip">Yes, the handle is hummusonrails. No, the hummus recipe is not open source.</p>
+  </div>
   <nav class="site-footer-links" aria-label="Social and feeds">
     <a href={`mailto:${SITE_METADATA.email}`}>Email</a>
+    <a href={SITE_METADATA.substack} target="_blank" rel="noopener noreferrer">Substack</a>
     <a href="https://www.youtube.com/@HummusOnRails" target="_blank" rel="noopener noreferrer">YouTube</a>
     <a href={SITE_METADATA.github} target="_blank" rel="noopener noreferrer">GitHub</a>
     <a href={SITE_METADATA.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn</a>

--- a/src/lib/substack.ts
+++ b/src/lib/substack.ts
@@ -1,0 +1,73 @@
+/**
+ * Build-time fetch of the latest essays from the Code and Conduct
+ * Substack via the public RSS feed (no API key required).
+ *
+ * The enclosure element usually carries the post cover image, but
+ * podcast episodes ship an mp3 enclosure instead, so only image
+ * enclosures are kept as covers.
+ *
+ * Every failure degrades to an empty list so the build never breaks
+ * on Substack hiccups; the homepage then renders just the subscribe
+ * card.
+ */
+
+import { SITE_METADATA } from '@/consts';
+
+const BASE_URL = SITE_METADATA.substack.replace(/\/$/, '');
+
+export const NEWSLETTER = {
+  name: 'Code and Conduct',
+  url: BASE_URL,
+  subscribeUrl: `${BASE_URL}/subscribe`,
+};
+
+export interface SubstackPost {
+  title: string;
+  subtitle: string;
+  url: string;
+  published: string;
+  cover: string | null;
+}
+
+const FEED_URL = `${NEWSLETTER.url}/feed`;
+
+function unwrapCdata(value: string): string {
+  return value.replace(/^<!\[CDATA\[/, '').replace(/\]\]>$/, '').trim();
+}
+
+export async function fetchLatestPosts(limit = 3): Promise<SubstackPost[]> {
+  try {
+    const res = await fetch(FEED_URL, { signal: AbortSignal.timeout(10000) });
+    if (!res.ok) throw new Error(`feed ${res.status}`);
+    const xml = await res.text();
+
+    const items = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].map((m) => m[1]);
+    const posts: SubstackPost[] = items.flatMap((item) => {
+      const title = item.match(/<title>([\s\S]*?)<\/title>/)?.[1];
+      const url = item.match(/<link>([\s\S]*?)<\/link>/)?.[1];
+      const published = item.match(/<pubDate>([\s\S]*?)<\/pubDate>/)?.[1];
+      if (!title || !url || !published) return [];
+
+      const subtitle = item.match(/<description>([\s\S]*?)<\/description>/)?.[1] ?? '';
+      // Attribute order inside <enclosure> is not guaranteed, so pull
+      // url and type out of the tag independently.
+      const enclosureTag = item.match(/<enclosure\b[^>]*>/)?.[0];
+      const enclosureUrl = enclosureTag?.match(/url="([^"]+)"/)?.[1];
+      const enclosureType = enclosureTag?.match(/type="([^"]+)"/)?.[1];
+      const cover = enclosureUrl && enclosureType?.startsWith('image/') ? enclosureUrl : null;
+
+      return [{
+        title: unwrapCdata(title),
+        subtitle: unwrapCdata(subtitle),
+        url: url.trim(),
+        published,
+        cover,
+      }];
+    });
+
+    return posts.slice(0, limit);
+  } catch (error) {
+    console.warn('[substack] feed unavailable, rendering subscribe card only:', (error as Error).message);
+    return [];
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,9 @@ import RootLayout from "@/layouts/RootLayout.astro";
 import ChatWidget from "@/components/ChatWidget.astro";
 import FormattedDate from "@/components/FormattedDate.astro";
 import { SITE_METADATA } from '@/consts';
-import { WORKSHOPS } from "@/data/workshops";
 import { getCollection } from 'astro:content';
 import { CHANNEL, fetchChannelVideos } from '@/lib/youtube';
+import { NEWSLETTER, fetchLatestPosts } from '@/lib/substack';
 
 export const prerender = true;
 
@@ -15,25 +15,63 @@ const posts = (await getCollection('blog'))
 const latestPosts = posts.slice(0, 3);
 
 const { videos, shorts } = await fetchChannelVideos();
+const essays = await fetchLatestPosts(3);
 ---
 
 <RootLayout title={SITE_METADATA.title} description={SITE_METADATA.description}>
-  <section class="hero">
-    <div>
-      <h1 class="hero-title">I build developer <em>communities</em> on four continents.</h1>
-      <p class="hero-sub">
-        I lead developer relations, wrote <a href="/book" class="modern-link">Vector Search with JavaScript</a> for
-        The Pragmatic Bookshelf, and teach hands-on workshops. Based between Tel Aviv and Miami.
-      </p>
-      <div class="hero-ctas">
+  <section class="id-hero" aria-label="Ben Greenberg">
+    <img class="id-hero-bg" src="/static/images/ben.jpeg" alt="" width="1422" height="944" loading="eager" />
+    <div class="id-hero-inner">
+      <h1 class="id-name">Ben Greenberg</h1>
+      <p class="id-tagline">builds developer communities on four continents</p>
+      <div class="id-ctas">
         <a class="cta cta-primary" href="/blog">Read the blog</a>
-        <a class="cta" href={`mailto:${SITE_METADATA.email}?subject=Speaking%20invitation`}>Book Ben to speak</a>
+        <a class="cta cta-onphoto" href={`mailto:${SITE_METADATA.email}?subject=Speaking%20invitation`}>Book Ben to speak</a>
       </div>
     </div>
-    <figure class="hero-photo">
-      <img src="/static/images/ben.jpeg" alt="Ben Greenberg giving a conference talk on stage" width="1422" height="944" loading="eager" />
-      <figcaption>Live from the keynote stage</figcaption>
+    <p class="id-hero-credit">Live from the keynote stage</p>
+  </section>
+
+  <section class="bio" aria-label="About Ben">
+    <figure class="bio-photo">
+      <img src="/static/images/new_home_picture.png" alt="Ben Greenberg mentoring developers at an event" loading="lazy" />
     </figure>
+    <div class="bio-text">
+      <h2 class="sr-only">About Ben</h2>
+      <fieldset class="bio-length">
+        <legend>About Ben. How long do you have?</legend>
+        <label>
+          Lightning talk
+          <input type="radio" name="bio-length" value="1" />
+        </label>
+        <label>
+          Coffee chat
+          <input type="radio" name="bio-length" value="2" />
+        </label>
+        <label>
+          Conference talk
+          <input type="radio" name="bio-length" value="3" checked />
+        </label>
+        <label>
+          Workshop
+          <input type="radio" name="bio-length" value="4" />
+        </label>
+        <label>
+          Keynote
+          <input type="radio" name="bio-length" value="5" />
+        </label>
+      </fieldset>
+      <div class="bio-copy" aria-live="polite">
+        <p>
+          <span data-length="1">Ben Greenberg leads developer relations at Arbitrum and builds developer communities on four continents.</span>
+          <span data-length="2"> He wrote <a href="/book">Vector Search with JavaScript</a> for The Pragmatic Bookshelf and splits his time between Tel Aviv and Miami.</span>
+          <span data-length="3"> Code is his second career. He spent a decade in adult education, community organizing, and non-profit management before shipping his first production code, and he brought all of it with him: communities work the same way whether they gather in a classroom or a terminal.</span>
+          <span data-length="4"> These days that mix looks like hands-on workshops on search engines, AI agents, and payment rails, plus <a href={NEWSLETTER.url} target="_blank" rel="noopener noreferrer">Code and Conduct</a>, a newsletter about what building software does to the people who build it. Along the way he picked up a Docker Captain badge, an Agentic AI Foundation ambassadorship, and a term on the Ruby Central board.</span>
+          <span data-length="5"> The through line is a belief that developer tools succeed when the people using them feel like they belong somewhere. So he keeps showing up in Nairobi, Denver, and Tel Aviv to teach the workshop and then stay for the hallway track.</span>
+        </p>
+      </div>
+      <p class="bio-more"><a href="/about">More about Ben &rarr;</a></p>
+    </div>
   </section>
 
   <section class="bento" aria-label="Explore the site">
@@ -44,7 +82,7 @@ const { videos, shorts } = await fetchChannelVideos();
       <p class="tile-body">Build AI-powered search systems with JavaScript. Published by The Pragmatic Bookshelf.</p>
     </a>
 
-    <div class="tile tile-plain t-writing">
+    <div class="tile t-writing">
       <span class="tile-eyebrow">Latest writing</span>
       <ul class="tile-list">
         {latestPosts.map((post) => (
@@ -57,20 +95,20 @@ const { videos, shorts } = await fetchChannelVideos();
       <a class="tile-cta" href="/blog">All posts</a>
     </div>
 
-    <a class="tile tile-plain t-talks" href="/talks">
+    <a class="tile t-talks" href="/talks">
       <span class="tile-eyebrow">On stage</span>
       <h2 class="tile-title">Conference talks</h2>
       <p class="tile-body">Talks from ETHDenver to PyCon Kenya, recorded and ready to watch.</p>
     </a>
 
-    <a class="tile tile-plain t-workshops" href="/projects">
+    <a class="tile t-workshops" href="/projects">
       <span class="tile-eyebrow">Hands-on</span>
       <h2 class="tile-title">Workshops</h2>
       <p class="tile-body">Build-along sessions on search engines, AI agents, and payment rails. Bring a laptop.</p>
     </a>
 
     <a class="tile t-about" href="/about">
-      <div class="tile-photo"><img src="/static/images/new_home_picture.png" alt="Ben Greenberg mentoring developers at an event" loading="lazy" /></div>
+      <div class="tile-photo"><img src="/static/images/with_group.jpeg" alt="Ben Greenberg with a developer community group" loading="lazy" /></div>
       <span class="tile-eyebrow">About</span>
       <h2 class="tile-title">Meet Ben</h2>
     </a>
@@ -82,6 +120,33 @@ const { videos, shorts } = await fetchChannelVideos();
       </div>
       <p class="tile-body">Photos, bios, and speaking details for events.</p>
     </a>
+  </section>
+
+  <section class="cc" aria-label="Code and Conduct newsletter">
+    <div class="cc-head">
+      <div>
+        <p class="page-eyebrow">The newsletter</p>
+        <h2 class="cc-title">Code and Conduct</h2>
+        <p class="cc-lede">Essays on technology, ethics, and the people caught between them. New writing lands on Substack first.</p>
+      </div>
+      <a class="cta cta-primary" href={NEWSLETTER.subscribeUrl} target="_blank" rel="noopener noreferrer">Subscribe free</a>
+    </div>
+
+    {essays.length > 0 && (
+      <div class="cc-posts">
+        {essays.map((post, i) => (
+          <a class="cc-card" href={post.url} target="_blank" rel="noopener noreferrer">
+            {post.cover && <span class="cc-cover"><img src={post.cover} alt="" loading="lazy" /></span>}
+            <span class="cc-card-body">
+              {i === 0 && <span class="cc-kicker">Latest essay</span>}
+              <span class="cc-card-title">{post.title}</span>
+              {post.subtitle && <span class="cc-card-sub">{post.subtitle}</span>}
+              <span class="cc-card-date"><FormattedDate date={new Date(post.published)} /></span>
+            </span>
+          </a>
+        ))}
+      </div>
+    )}
   </section>
 
   <section class="yt" aria-label="Learn with Ben on YouTube">
@@ -124,4 +189,3 @@ const { videos, shorts } = await fetchChannelVideos();
   <ChatWidget />
 
 </RootLayout>
-

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,6 +58,7 @@
   --chat-topbar: #141311;
   --font-display: 'Sohne', sans-serif;
   --font-mono: 'Sohne Mono', ui-monospace, monospace;
+  --nav-height: 3.6rem;
   color-scheme: dark;
   --chat-input-shadow: rgba(0, 0, 0, 0.25);
 }
@@ -974,13 +975,18 @@ html[data-theme="light"] .chat-avatar-user {
   text-transform: uppercase;
   color: var(--text-secondary);
   text-decoration: none;
-  padding: 0.35rem 0.1rem;
-  border-bottom: 2px solid transparent;
+  padding: 0.45rem 0.7rem;
+  border-radius: 3px;
+  background: var(--dark-surface);
+  transition: background 120ms ease-in-out, color 120ms ease-in-out;
 }
-.site-nav-link:hover { color: var(--text-primary); }
+.site-nav-link:hover {
+  background: var(--accent-wash);
+  color: var(--accent-text);
+}
 .site-nav-link[aria-current="page"] {
-  color: var(--text-primary);
-  border-bottom-color: var(--accent);
+  background: var(--accent);
+  color: #1a1206;
 }
 
 .site-theme-toggle {
@@ -1030,6 +1036,12 @@ html[data-theme="light"] .chat-avatar-user {
   text-transform: uppercase;
 }
 .site-footer-sign em { font-style: normal; color: var(--accent-text); }
+.site-footer-sign { margin: 0; }
+.site-footer-quip {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0.4rem 0 0;
+}
 .site-footer-links {
   display: flex;
   flex-wrap: wrap;
@@ -1045,43 +1057,216 @@ html[data-theme="light"] .chat-avatar-user {
   letter-spacing: 0.06em;
 }
 
-/* --- Hero --- */
-.hero {
+/* --- Identity hero (full-viewport, photo-backed) --- */
+.id-hero {
+  position: relative;
+  min-height: calc(100svh - var(--nav-height));
   display: grid;
-  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
-  gap: clamp(1.5rem, 4vw, 3.5rem);
-  align-items: end;
-  padding: clamp(2.5rem, 7vw, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vw, 3rem);
-  max-width: 1280px;
-  margin: 0 auto;
+  place-content: center;
+  text-align: center;
+  overflow: hidden;
+  padding: clamp(2.5rem, 7vw, 5rem) clamp(1rem, 4vw, 2.5rem);
 }
-.hero-eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--accent-text);
-  margin-bottom: 1.1rem;
+.id-hero-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 30%;
+  border-radius: 0;
 }
-.hero-title {
+.id-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(16, 15, 12, 0.5), rgba(20, 19, 17, 0.86));
+  z-index: 1;
+}
+.id-hero-inner { position: relative; z-index: 2; }
+.id-name {
   font-family: var(--font-display);
   font-weight: 600;
-  font-size: clamp(2.4rem, 6.4vw, 5.2rem);
-  line-height: 0.97;
+  font-size: clamp(2.8rem, 10.5vw, 7.5rem);
+  line-height: 0.92;
   letter-spacing: -0.02em;
   text-transform: uppercase;
-  color: var(--text-primary);
+  color: #f5efe6;
   margin: 0;
 }
-.hero-title em { font-style: normal; color: var(--accent); }
-.hero-sub {
-  margin-top: 1.4rem;
-  max-width: 34rem;
-  font-size: 1.05rem;
-  line-height: 1.6;
+.id-name::after {
+  content: "";
+  display: block;
+  width: min(70%, 16ch);
+  height: 4px;
+  border-radius: 2px;
+  background: var(--accent);
+  margin: 1.1rem auto 0;
+}
+.id-tagline {
+  font-family: var(--font-mono);
+  font-size: clamp(0.8rem, 2vw, 1.05rem);
+  letter-spacing: 0.16em;
+  text-transform: lowercase;
+  color: rgba(245, 239, 230, 0.85);
+  margin: 1.2rem 0 0;
+}
+.id-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.8rem;
+  margin-top: 2.2rem;
+}
+.cta.cta-onphoto {
+  border-color: rgba(245, 239, 230, 0.45);
+  color: #f5efe6;
+}
+.cta.cta-onphoto:hover { border-color: #ff9f45; color: #ff9f45; }
+.id-hero-credit {
+  position: absolute;
+  right: 1rem;
+  bottom: 0.9rem;
+  z-index: 2;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: rgba(245, 239, 230, 0.6);
+}
+@supports (animation-timeline: scroll()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .id-hero-inner {
+      animation: id-hero-shrink linear both;
+      animation-timeline: scroll();
+      animation-range: 0 80svh;
+    }
+    @keyframes id-hero-shrink {
+      to {
+        transform: scale(0.9) translateY(-1.6rem);
+        opacity: 0.3;
+      }
+    }
+  }
+}
+
+/* --- Interactive bio (pick your length) --- */
+.bio {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  gap: clamp(1.5rem, 4vw, 3.5rem);
+  align-items: center;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 6vw, 5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vw, 3rem);
+}
+.bio-photo { margin: 0; }
+.bio-photo img {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+  border-radius: 4px;
+}
+/* The picker only works where :has() works; without it the full bio
+   shows and the dead control stays hidden. */
+.bio-length {
+  display: none;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.4rem;
+  border: none;
+  margin: 0 0 1.6rem;
+  padding: 0;
+}
+@supports selector(:has(*)) {
+  .bio-length { display: flex; }
+}
+.bio-length legend {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(1.3rem, 2.6vw, 1.9rem);
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  width: 100%;
+  margin: 0 0 1.4rem;
+  padding: 0;
+}
+.bio-length label {
+  --dot: 6px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 26px 2px 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-radius: 3px;
+  outline: 1px solid transparent;
+  cursor: pointer;
+  transition: color 0.1s linear;
+}
+.bio-length label::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: calc((100% - 14px) / 2);
+  width: var(--dot);
+  height: var(--dot);
+  border-radius: 50%;
+  background: var(--text-muted);
+  border: calc((14px - var(--dot)) / 2) solid var(--dark-border);
+  transition: width 0.1s linear, height 0.1s linear, border-width 0.1s linear, background 0.1s linear;
+}
+.bio-length label:has(:focus-visible) {
+  outline: 1px solid var(--accent);
+  outline-offset: 4px;
+}
+.bio-length label:has(:checked) {
+  color: var(--text-primary);
+}
+.bio-length label:has(:checked)::before {
+  --dot: 12px;
+  background: var(--accent);
+  border-color: var(--dark-border);
+}
+.bio-length input {
+  position: absolute;
+  opacity: 0;
+}
+.bio-copy p {
+  margin: 0;
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+  line-height: 1.65;
   color: var(--text-secondary);
 }
-.hero-ctas { display: flex; flex-wrap: wrap; gap: 0.8rem; margin-top: 1.8rem; }
+.bio-copy a {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-underline-offset: 3px;
+}
+@supports selector(:has(*)) {
+  .bio-copy [data-length] { display: none; }
+  .bio:has([value="1"]:checked) [data-length="1"] { display: inline; }
+  .bio:has([value="2"]:checked) :is([data-length="1"], [data-length="2"]) { display: inline; }
+  .bio:has([value="3"]:checked) :is([data-length="1"], [data-length="2"], [data-length="3"]) { display: inline; }
+  .bio:has([value="4"]:checked) :is([data-length="1"], [data-length="2"], [data-length="3"], [data-length="4"]) { display: inline; }
+  .bio:has([value="5"]:checked) [data-length] { display: inline; }
+}
+.bio-more { margin: 1.4rem 0 0; }
+.bio-more a {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+.bio-more a:hover { color: var(--accent-text); }
+
 .cta {
   display: inline-flex;
   align-items: center;
@@ -1105,24 +1290,11 @@ html[data-theme="light"] .chat-avatar-user {
 }
 .cta-primary:hover { background: var(--accent-text); color: #1a1206; }
 
-.hero-photo { position: relative; border-radius: 0.9rem; overflow: hidden; border: 1px solid var(--dark-border); }
-.hero-photo img { display: block; width: 100%; height: 100%; object-fit: cover; aspect-ratio: 4 / 3; }
-.hero-photo figcaption {
-  position: absolute;
-  left: 0.8rem;
-  bottom: 0.8rem;
-  font-size: 0.78rem;
-  background: rgba(12, 11, 9, 0.72);
-  color: #f5efe6;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.4rem;
-}
-
-/* --- Bento --- */
+/* --- Bento (tight grout) --- */
 .bento {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 5px;
   max-width: 1280px;
   margin: 0 auto;
   padding: clamp(2rem, 5vw, 3.5rem) clamp(1rem, 4vw, 2.5rem) clamp(3rem, 6vw, 4.5rem);
@@ -1132,16 +1304,16 @@ html[data-theme="light"] .chat-avatar-user {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  border: 1px solid var(--dark-border);
-  border-radius: 0.9rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
   background: var(--dark-surface);
-  padding: 1.4rem;
+  padding: 1.3rem;
   text-decoration: none;
   color: var(--text-primary);
   overflow: hidden;
-  transition: border-color 140ms ease, transform 140ms ease;
+  transition: background 120ms ease-in-out, border-color 120ms ease-in-out;
 }
-a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
+a.tile:hover { background: var(--dark-bg); border-color: var(--dark-border); }
 .tile-eyebrow {
   font-family: var(--font-mono);
   font-size: 0.68rem;
@@ -1167,8 +1339,8 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
   color: var(--text-primary);
 }
 .tile:hover .tile-cta { color: var(--accent-text); }
-.tile-photo { margin: -1.4rem -1.4rem 0.4rem; }
-.tile-photo img { width: 100%; height: 11rem; object-fit: cover; display: block; }
+.tile-photo { margin: -1.3rem -1.3rem 0.4rem; }
+.tile-photo img { width: 100%; height: 11rem; object-fit: cover; display: block; border-radius: 0; }
 .tile-cover { display: flex; justify-content: center; padding: 0.4rem 0 0.6rem; }
 .tile-cover img { width: min(11rem, 70%); border-radius: 0.35rem; box-shadow: 0 12px 30px rgba(0,0,0,0.35); }
 .tile-list { display: grid; gap: 0.85rem; margin: 0.2rem 0 0; padding: 0; list-style: none; }
@@ -1184,7 +1356,6 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
   margin-bottom: 0.15rem;
 }
 
-.tile-plain { background: transparent; }
 .t-book { grid-column: span 5; }
 .t-writing { grid-column: span 7; }
 .t-talks { grid-column: span 4; }
@@ -1204,8 +1375,11 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
   .t-book, .t-writing, .t-talks, .t-workshops, .t-about { grid-column: span 6; }
   .t-media { flex-direction: column; align-items: flex-start; }
 }
+@media (max-width: 820px) {
+  .bio { grid-template-columns: 1fr; }
+  .bio-photo img { aspect-ratio: 16 / 10; }
+}
 @media (max-width: 640px) {
-  .hero { grid-template-columns: 1fr; align-items: start; }
   .t-book, .t-writing, .t-talks, .t-workshops, .t-about, .t-media { grid-column: span 12; }
   .site-nav-links { display: none; }
   .site-nav-links[data-open="true"] {
@@ -1314,6 +1488,90 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
 .cw-input-wrap { border-top: 1px solid var(--dark-border); padding: 0.8rem 1rem 0.9rem; }
 .cw-root .chat-disclaimer { margin-top: 0.5rem; }
 
+/* --- Code and Conduct newsletter section --- */
+.cc {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(3rem, 6vw, 4.5rem);
+}
+.cc-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--dark-border);
+  padding-top: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 1.6rem;
+}
+.cc-title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+}
+.cc-lede { color: var(--text-secondary); margin: 0; max-width: 34rem; }
+.cc-posts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 5px;
+}
+.cc-card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: var(--dark-surface);
+  overflow: hidden;
+  transition: background 120ms ease-in-out, border-color 120ms ease-in-out;
+}
+.cc-card:hover { background: var(--dark-bg); border-color: var(--dark-border); }
+.cc-cover { display: block; }
+.cc-cover img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+  border-radius: 0;
+}
+.cc-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem 1.1rem 1.2rem;
+}
+.cc-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-text);
+}
+.cc-card-title {
+  color: var(--text-primary);
+  font-weight: 500;
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+.cc-card-sub { color: var(--text-secondary); font-size: 0.88rem; line-height: 1.45; }
+.cc-card-date {
+  margin-top: auto;
+  padding-top: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+@media (max-width: 820px) {
+  .cc-posts { grid-template-columns: 1fr; }
+}
+
 /* --- YouTube channel section --- */
 .yt {
   max-width: 1280px;
@@ -1344,22 +1602,22 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
 .yt-videos {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 5px;
 }
 .yt-card {
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
   text-decoration: none;
-  border: 1px solid var(--dark-border);
-  border-radius: 0.9rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
   background: var(--dark-surface);
   padding: 0.8rem;
-  transition: border-color 140ms ease, transform 140ms ease;
+  transition: background 120ms ease-in-out, border-color 120ms ease-in-out;
 }
-.yt-card:hover { border-color: var(--accent); transform: translateY(-2px); }
-.yt-thumb { position: relative; display: block; border-radius: 0.5rem; overflow: hidden; }
-.yt-thumb img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+.yt-card:hover { background: var(--dark-bg); border-color: var(--dark-border); }
+.yt-thumb { position: relative; display: block; border-radius: 3px; overflow: hidden; }
+.yt-thumb img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; border-radius: 0; }
 .yt-play {
   position: absolute;
   right: 0.6rem;
@@ -1394,7 +1652,7 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: minmax(9rem, 1fr);
-  gap: 0.8rem;
+  gap: 5px;
   overflow-x: auto;
   padding-bottom: 0.4rem;
   scrollbar-width: thin;
@@ -1402,13 +1660,13 @@ a.tile:hover { border-color: var(--accent); transform: translateY(-2px); }
 .yt-short {
   position: relative;
   display: block;
-  border-radius: 0.7rem;
+  border-radius: 4px;
   overflow: hidden;
   border: 1px solid var(--dark-border);
   text-decoration: none;
 }
 .yt-short:hover { border-color: var(--accent); }
-.yt-short img { display: block; width: 100%; aspect-ratio: 9 / 16; object-fit: cover; }
+.yt-short img { display: block; width: 100%; aspect-ratio: 9 / 16; object-fit: cover; border-radius: 0; }
 .yt-short-title {
   position: absolute;
   inset: auto 0 0 0;


### PR DESCRIPTION
### **User description**
## What

Redesigns the homepage around an identity-first structure while keeping the site's palette, Sohne type, and voice.

- Full-viewport identity hero: name + four-continents tagline over the keynote photo, scroll-shrink where `animation-timeline: scroll()` is supported, reduced-motion respected
- Interactive bio with a length selector themed to conference formats (Lightning talk, Coffee chat, Conference talk, Workshop, Keynote); hidden entirely in browsers without `:has()`, which instead show the full bio
- Tight-grout grids: 5px gaps, 3-4px radii, and a shared hover treatment (background swaps to page color, border appears) across bento tiles, newsletter cards, and YouTube cards
- Block-style nav links with a distinct active state vs hover
- New Code and Conduct section: `src/lib/substack.ts` fetches the Substack RSS at build time, same fail-open pattern as the YouTube integration; covers come only from image enclosures so podcast posts degrade cleanly
- Footer: hummus quip and Substack link

## Verification

- Build passes; latest Substack essays render in the prerendered homepage
- Screenshotted desktop light and dark themes, bio selector exercised in-browser, console clean
- Independent fresh-context review pass ran before commit; all 10 findings addressed (thumbnail radius regression, :has() fallback, enclosure attribute order, aria-live on the swapped bio, heading outline, nav active state, hardcoded nav height, footer margin hack, on-photo hover color, copy tightening)


___

### **PR Type**
Enhancement


___

### **Description**
- Redesigns homepage around identity hero

- Adds interactive progressive-enhanced bio

- Fetches Substack essays at build time

- Tightens cards, navigation, and footer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  homepage["Homepage"]
  hero["Identity hero"]
  bio["Interactive bio"]
  substack["Substack feed"]
  cards["Tight-grout card styling"]
  footer["Footer links"]

  homepage -- "introduces" --> hero
  homepage -- "adds" --> bio
  homepage -- "renders" --> substack
  homepage -- "restyles" --> cards
  homepage -- "updates" --> footer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>substack.ts</strong><dd><code>Add Substack RSS feed integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/substack.ts

<ul><li>Adds build-time Substack RSS fetching.<br> <li> Exposes <code>NEWSLETTER</code> metadata and post types.<br> <li> Parses titles, descriptions, dates, URLs, and image enclosures.<br> <li> Fails open with an empty post list.</ul>


</details>


  </td>
  <td><a href="https://github.com/hummusonrails/personal-site/pull/76/files#diff-4fef24a0d0df44908a5a72e54d178778f894506316041b8a07d025c0976721f4">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>global.css</strong><dd><code>Restyle homepage identity and content sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/styles/global.css

<ul><li>Adds full-viewport identity hero and scroll animation styles.<br> <li> Introduces responsive interactive bio styling using <code>:has()</code>.<br> <li> Adds Code and Conduct newsletter card layout.<br> <li> Updates navigation, bento, YouTube, and footer styling.</ul>


</details>


  </td>
  <td><a href="https://github.com/hummusonrails/personal-site/pull/76/files#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9e">+321/-63</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SiteFooter.astro</strong><dd><code>Add footer quip and Substack link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/SiteFooter.astro

<ul><li>Adds a hummus-themed footer quip.<br> <li> Adds a Substack link to footer feeds.<br> <li> Wraps footer signoff copy for improved layout.</ul>


</details>


  </td>
  <td><a href="https://github.com/hummusonrails/personal-site/pull/76/files#diff-970ac7b79d2afbf4fdc2b03ca93464bcbd67b883a9c554bedcda3018dbebdfd0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.astro</strong><dd><code>Rebuild homepage with bio and newsletter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/index.astro

<ul><li>Replaces the legacy hero with an identity-first photo hero.<br> <li> Adds selectable-length bio content and about link.<br> <li> Fetches and renders latest Code and Conduct essays.<br> <li> Updates bento imagery and removes <code>tile-plain</code> usage.</ul>


</details>


  </td>
  <td><a href="https://github.com/hummusonrails/personal-site/pull/76/files#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663">+82/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

